### PR TITLE
Feature/index creation jenkinsfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,51 @@
+#!groovy
+@Library('jenkins-pipeline-shared') _
+
+pipeline {
+    parameters {
+        string(name: 'index_name', defaultValue: 'example-bi-dev', description: 'Name of the ElasticSearch index to create.')
+    }
+    environment {
+        MASTER_BRANCH = "master"
+        ELASTIC_HOST = ""
+        ELASTIC_PORT = ""
+        INDEX_NAME = "${params.index_name}"
+        INDEX_JSON_PATH = "./business-index-api/conf/index.json"
+    }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '30'))
+        timeout(time: 30, unit: 'MINUTES')
+        timestamps()
+    }
+    agent any
+    stages {
+        stage('Checkout'){
+            agent any
+            when{ branch MASTER_BRANCH }
+            steps {
+                dir('business-index-api') {
+                    git(url: "https://github.com/ONSdigital/business-index-api.git", branch: "master")
+                }
+            }
+        }
+
+        stage('Index Exists?'){
+            agent any
+            when{ branch MASTER_BRANCH }
+            steps {
+                colourText("info", "Checking to see if index [$INDEX_NAME] exists")
+                sh "business-index-api/conf/scripts/index_exists.sh $ELASTIC_HOST $ELASTIC_PORT $INDEX_NAME"
+                colourText("info", "No ElasticSearch index [${env.INDEX_NAME}] exists, continuing to Create Index step.")
+            }
+        }
+
+        stage('Create Index'){
+            agent any
+            when{ branch MASTER_BRANCH }
+            steps {
+                colourText("info", "Creating index [$INDEX_NAME]")
+                sh "business-index-api/conf/scripts/create_index.sh $ELASTIC_HOST $ELASTIC_PORT $INDEX_NAME $INDEX_JSON_PATH"
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # business-index-elastic-index
-Elastic Search Index definition for BI
+This repository holds the `Jenkinsfile` used for the creation of an ElasticSearch index and data load, for use by the `business-index-api`.
+
+All shell scripts and JSON files used by the `Jenkinsfile` are stored in the `business-index-api`, in `business-index-api/conf/scripts` and `business-index-api/conf/index.json`.


### PR DESCRIPTION
- Add `Jenkinsfile` with Checkout, Index Exists and Create Index steps, with a parameter for `index_name`
- Add shell scripts for checking if an index exists and for creating a new index - these have been moved to the `business-index-api`, [here](https://github.com/ONSdigital/business-index-api/tree/feature/elastic-shell-scripts/conf/scripts)

Previously, if the index name provided by the user already existed in ElasticSearch, it would be deleted. After further clarification, it was decided to not delete the index and to fail the script instead.

Environment variables used by the `Jenkinsfile` (ElasticSearch host, port, index name) have been left empty in the `environment` section, they will be added as actual environment variables once other parts of the pipeline have been tested.