### PR TITLE
Add trigger_oozie_job script and Jenkinsfile step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
         ELASTIC_HOST = ""
         ELASTIC_PORT = ""
         INDEX_NAME = "${params.index_name}"
+        ENVIRONMENT = "dev"
+        SSH_HOST = ""
+        OOZIE_URL = ""
         INDEX_JSON_PATH = "./business-index-api/conf/index.json"
     }
     options {
@@ -21,7 +24,7 @@ pipeline {
     stages {
         stage('Checkout'){
             agent any
-            when{ branch MASTER_BRANCH }
+            when { branch MASTER_BRANCH }
             steps {
                 dir('business-index-api') {
                     git(url: "https://github.com/ONSdigital/business-index-api.git", branch: "master")
@@ -31,7 +34,7 @@ pipeline {
 
         stage('Index Exists?'){
             agent any
-            when{ branch MASTER_BRANCH }
+            when { branch MASTER_BRANCH }
             steps {
                 colourText("info", "Checking to see if index [$INDEX_NAME] exists")
                 sh "business-index-api/conf/scripts/index_exists.sh $ELASTIC_HOST $ELASTIC_PORT $INDEX_NAME"
@@ -41,10 +44,25 @@ pipeline {
 
         stage('Create Index'){
             agent any
-            when{ branch MASTER_BRANCH }
+            when { branch MASTER_BRANCH }
             steps {
                 colourText("info", "Creating index [$INDEX_NAME]")
                 sh "business-index-api/conf/scripts/create_index.sh $ELASTIC_HOST $ELASTIC_PORT $INDEX_NAME $INDEX_JSON_PATH"
+            }
+        }
+
+        stage('Trigger Oozie Job'){
+            agent any
+            when { branch MASTER_BRANCH }
+            steps {
+                colourText("info", "Triggering Oozie Job to load ElasticSearch index [$INDEX_NAME]")
+                // We need to get the (environment specific) job.properties file from Gitlab
+                dir('configuration') {
+                    git(url: "$GITLAB_URL/BusinessIndex/business-index-elastic-index.git", credentialsId: "bi-gitlab-id", branch: "master")
+                }
+                sshagent(credentials: ["bi-dev-ci-ssh-key"]) {
+                    sh "./scripts/trigger_oozie_job.sh $ENVIRONMENT $SSH_HOST $OOZIE_URL"
+                }
             }
         }
     }

--- a/scripts/trigger_oozie_job.sh
+++ b/scripts/trigger_oozie_job.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# This script will scp a job.properties configuration file onto the server which will
+# be used to run the business-index parquet ingestion oozie job, which will result
+# in a populated ElasticSearch index.
+
+SCRIPT_NAME=$0
+REQUIRED_NUM_ARGS=3
+
+# Fail fast if we get any errors
+set -e
+
+usage() {
+    echo "usage: ${SCRIPT_NAME} env host oozie_home"
+    echo "  env                     environment dev/test/beta"
+    echo "  host                    ssh target host"
+    echo "  oozie_home              oozie home url"
+    exit 1
+}
+
+# Fail the script if we recieve an incorrect number of arguments
+if [ $# -ne $REQUIRED_NUM_ARGS ] ; then
+    echo 'Error, you need to provide the correct number of arguments.'
+    usage
+fi
+
+ENV=$1
+HOST=$2
+OOZIE_HOME=$3
+
+# Create the directory for our job.properties file, then send it using scp
+ssh bi-${ENV}-ci@${HOST} "mkdir -p bi-${ENV}-ingestion-parquet"
+scp ./configuration/${ENV}/job.properties bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet
+echo "Successfully transfered ./configuration/${ENV}/job.properties to bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet"
+
+# Trigger the oozie job and get the job id, remove unused chars from the id and then poll it.
+# JOB_ID is something like 'job: 213871982-213123123-asdasd', we remove 'job: '
+ssh -tt bi-${ENV}-ci@${HOST} OOZIE_HOME=$OOZIE_HOME ENV=$ENV 'bash -s' << 'ENDSSH'
+    TIMEOUT=1000
+    INTERVAL=1
+    OOZIE_ID_INDEX=5
+
+    JOB_ID_UNFORMATTED=$(oozie job --oozie ${OOZIE_HOME} -config ./bi-${ENV}-ingestion-parquet/job.properties -run)
+
+    JOB_ID=${JOB_ID_UNFORMATTED:${OOZIE_ID_INDEX}}
+    echo "JOB_ID: [${JOB_ID}]"
+    
+    oozie job --oozie ${OOZIE_HOME} -poll ${JOB_ID} -interval ${INTERVAL} -timeout ${TIMEOUT} -verbose'
+ENDSSH
+
+echo "Oozie job was successful, data has been loaded into ElasticSearch index."


### PR DESCRIPTION
- Add trigger_oozie_job.sh which triggers an oozie job over ssh
- Add step in Jenkinsfile for triggering the oozie job

The `trigger_oozie_job.sh` looks messy as when another `ssh user@host cmd` is used, any variables set in the previous commands are not persisted, hence why one long command with `;` separators are required. There is probably a better way of doing this. 