### PR TITLE
Add fixed sed command

### DIFF
--- a/scripts/trigger_oozie_job.sh
+++ b/scripts/trigger_oozie_job.sh
@@ -32,7 +32,8 @@ INDEX_NAME=$4
 
 # Create the directory for our job.properties file and replace the INDEX_NAME value, then send it using scp
 ssh bi-${ENV}-ci@${HOST} "mkdir -p bi-${ENV}-ingestion-parquet"
-sed -i '' -e "s/\${INDEX_NAME}/${INDEX_NAME}/g" ./configuration/${ENV}/job.properties
+sed -e "s/{INDEX_NAME}/${INDEX_NAME}/g" ./configuration/${ENV}/job.properties > ./configuration/${ENV}/updated_job.properties
+mv ./configuration/${ENV}/updated_job.properties ./configuration/${ENV}/job.properties
 scp ./configuration/${ENV}/job.properties bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet
 echo "Successfully transfered ./configuration/${ENV}/job.properties to bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet"
 


### PR DESCRIPTION
There was an issue on Jenkins with `sed`, which seems to be due to differences between GNU/Mac OS `sed`, more information can be found [here](https://stackoverflow.com/a/43453459).

The format of the `sed` command had to change, removing the `''` after the `-i` flag and changing the position of the file path.