### PR TITLE
Add kinit command to trigger oozie script

### DIFF
--- a/scripts/trigger_oozie_job.sh
+++ b/scripts/trigger_oozie_job.sh
@@ -38,10 +38,13 @@ scp ./configuration/${ENV}/job.properties bi-${ENV}-ci@${HOST}:bi-${ENV}-ingesti
 echo "Successfully transfered ./configuration/${ENV}/job.properties to bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet"
 
 # Trigger the oozie job and get the job id, remove unused chars from the id and then poll it.
+# kinit creates a new kerboros authentication key which solves an authentication error
 # ENVIRONMENT and INDEX_NAME are exported in the ssh step so that the job.properties file
 # used by Oozie can use them
 # JOB_ID is something like 'job: 213871982-213123123-asdasd', we remove 'job: '
 ssh -tt bi-${ENV}-ci@${HOST} OOZIE_HOME=$OOZIE_HOME ENV=$ENV 'bash -s' << 'ENDSSH'
+    kinit
+
     TIMEOUT=1000
     INTERVAL=1
     OOZIE_ID_INDEX=5


### PR DESCRIPTION
- Add use of `kinit` command prior to triggering Oozie job to solve occasional Kerboros authentication error. The `kinit` command will create/refresh the Kerboros authentication key.