### PR TITLE
Add environment to ssh agent name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                 dir('configuration') {
                     git(url: "$GITLAB_URL/BusinessIndex/business-index-elastic-index.git", credentialsId: "bi-gitlab-id", branch: "master")
                 }
-                sshagent(credentials: ["bi-dev-ci-ssh-key"]) {
+                sshagent(credentials: ["bi-${ENVIRONMENT}-ci-ssh-key"]) {
                     sh "./scripts/trigger_oozie_job.sh $ENVIRONMENT $SSH_HOST $OOZIE_URL $INDEX_NAME"
                 }
             }


### PR DESCRIPTION
- In the `Jenkinsfile`, when specifying an `sshagent` to use, use dynamic `${ENVIRONMENT}` rather than hardcoded `dev`