### PR TITLE
Fix/reg 1724 parse oozie status

### DIFF
--- a/scripts/trigger_oozie_job.sh
+++ b/scripts/trigger_oozie_job.sh
@@ -53,6 +53,10 @@ ssh -tt bi-${ENV}-ci@${HOST} OOZIE_HOME=$OOZIE_HOME ENV=$ENV 'bash -s' << 'ENDSS
     JOB_ID=${JOB_ID_UNFORMATTED:${OOZIE_ID_INDEX}}
     echo "JOB_ID: [${JOB_ID}]"
 
+    # The oozie poll command does not exit once a job status changes from RUNNING -> KILLED or SUCCEEDED etc, so we need
+    # to parse the output of the polling and exit with an appropriate error code once the status is not RUNNING. This
+    # command will only finish once the status is not RUNNING, succeeding if the status is SUCCEEDED or failing for
+    # any other status.
     oozie job -poll ${JOB_ID} -interval ${INTERVAL} --oozie ${OOZIE_HOME} -timeout ${TIMEOUT} -verbose | while read LOGLINE
     do
         echo status: [${LOGLINE}]


### PR DESCRIPTION
The `oozie job -poll $jobId` command does not exit once it has reached a completed status (SUCCEEDED, KILLED etc.), so the output of the polling needs to be parsed so that based upon the status, the command can be exited with the appropriate exit code.

Once the `oozie job -poll $jobId` command has been exited, we can use that exit code to decide whether or not to fail the script. E.g. if the `oozie job -poll $jobId` command exits with a non-zero exit code, the whole script will fail.

The docs for the `oozie` poll command can be found [here](https://oozie.apache.org/docs/4.2.0/DG_CommandLineTool.html#Polling_an_Oozie_job).