### PR TITLE
Add use of kinit command prior to triggerring Oozie job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,8 +61,10 @@ pipeline {
                 dir('configuration') {
                     git(url: "$GITLAB_URL/BusinessIndex/business-index-elastic-index.git", credentialsId: "bi-gitlab-id", branch: "master")
                 }
-                sshagent(credentials: ["bi-dev-ci-ssh-key"]) {
-                    sh "./scripts/trigger_oozie_job.sh $ENVIRONMENT $SSH_HOST $OOZIE_URL $INDEX_NAME"
+                withCredentials([usernamePassword(credentialsId: "bi-${ENVIRONMENT}-ci-user-pass", passwordVariable: "PASSWORD", usernameVariable: "USERNAME")]) {
+                    sshagent(credentials: ["bi-dev-ci-ssh-key"]) {
+                        sh "./scripts/trigger_oozie_job.sh $PASSWORD $ENVIRONMENT $SSH_HOST $OOZIE_URL $INDEX_NAME"
+                    }
                 }
             }
         }

--- a/scripts/trigger_oozie_job.sh
+++ b/scripts/trigger_oozie_job.sh
@@ -5,13 +5,14 @@
 # in a populated ElasticSearch index.
 
 SCRIPT_NAME=$0
-REQUIRED_NUM_ARGS=4
+REQUIRED_NUM_ARGS=5
 
 # Fail fast if we get any errors
 set -e
 
 usage() {
     echo "usage: ${SCRIPT_NAME} env host oozie_home"
+    echo "  password                password for bi-ENV-ci"
     echo "  env                     environment dev/test/beta"
     echo "  host                    ssh target host"
     echo "  oozie_home              oozie home url"
@@ -25,10 +26,11 @@ if [ $# -ne $REQUIRED_NUM_ARGS ] ; then
     usage
 fi
 
-ENV=$1
-HOST=$2
-OOZIE_HOME=$3
-INDEX_NAME=$4
+PASSWORD=$1
+ENV=$2
+HOST=$3
+OOZIE_HOME=$4
+INDEX_NAME=$5
 
 # Create the directory for our job.properties file and replace the INDEX_NAME value, then send it using scp
 ssh bi-${ENV}-ci@${HOST} "mkdir -p bi-${ENV}-ingestion-parquet"
@@ -37,11 +39,19 @@ mv ./configuration/${ENV}/updated_job.properties ./configuration/${ENV}/job.prop
 scp ./configuration/${ENV}/job.properties bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet
 echo "Successfully transfered ./configuration/${ENV}/job.properties to bi-${ENV}-ci@${HOST}:bi-${ENV}-ingestion-parquet"
 
+# Replace special characters
+REPLACED_PASSWORD=$(echo ''"$PASSWORD"'' | awk '{gsub( /[(*|`$&)]/, "\\\\&"); print $0}')
+
 # Trigger the oozie job and get the job id, remove unused chars from the id and then poll it.
 # ENVIRONMENT and INDEX_NAME are exported in the ssh step so that the job.properties file
 # used by Oozie can use them
 # JOB_ID is something like 'job: 213871982-213123123-asdasd', we remove 'job: '
-ssh -tt bi-${ENV}-ci@${HOST} OOZIE_HOME=$OOZIE_HOME ENV=$ENV 'bash -s' << 'ENDSSH'
+ssh -tt bi-${ENV}-ci@${HOST} BI_PASSWORD=$REPLACED_PASSWORD OOZIE_HOME=$OOZIE_HOME ENV=$ENV 'bash -s' << 'ENDSSH'
+    set -e
+
+    # Refresh kerboros authentication
+    echo "${BI_PASSWORD}" | kinit
+
     TIMEOUT=1000
     INTERVAL=1
     OOZIE_ID_INDEX=5


### PR DESCRIPTION
- Add use of kinit command prior to triggering Oozie job to solve occasional Kerboros authentication error. The kinit command will create/refresh the Kerboros authentication key.

Note: The password must have all special characters preceded with a `\`. Using `''"${PASSWORD}"''` or `${PASSWORD@Q}` did not work whilst SSH'd into the server, so the `awk` solution was used instead.