### PR TITLE
Fix ES index name generation to allow multiple runs per day

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         ELASTIC_PORT = "${BI_ELASTIC_PORT}"
         ENVIRONMENT = "${params.ENVIRONMENT}"
         ALIAS = "bi-${ENVIRONMENT}"
-        INDEX_NAME = "bi-${ENVIRONMENT}-${new Date().format('ddMMyyyy')}"
+        INDEX_NAME = "bi-${ENVIRONMENT}-${new Date().format('ddMMyyyy-HHmmss')}"
         SSH_HOST = "${BI_CDHUT_SSH_HOST}"
         OOZIE_URL = "${BI_OOZIE_URL}"
         INDEX_JSON_PATH = "./business-index-api/conf/updated_index.json"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The index definition for the ElasticSearch index can be found in [business-index
 
 ### Environment
 
-When defining the variables which will be available throughout the `Jenkinsfile`, the index name is generated using the `ENVIRONMENT` build parameter and the current date, in `ddMMyyyy` format. E.g. `bi-${ENVIRONMENT}-ddMMyyyy` -> `bi-dev-03082018`.
+When defining the variables which will be available throughout the `Jenkinsfile`, the index name is generated using the `ENVIRONMENT` build parameter and the current date, in `ddMMyyyy-HHmmss` format. E.g. `bi-${ENVIRONMENT}-ddMMyyyy-HHmmss` -> `bi-dev-01112018-130248`.
 
 ### Checkout
 


### PR DESCRIPTION
The ES index name is generated by formatting current date as ddMMyyyy
which causes failure if a build is run more than once a day since there
is a check to not re-create an existing index (or delete it).

This change amends the name generation to use ddMMyyyy-HHmmss to allow
running multiple builds a day.